### PR TITLE
Added time-based show and hide functionality to actionbar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,11 @@
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
+
+        <repository>
+            <id>minebench-repo</id>
+            <url>https://repo.minebench.de/</url>
+        </repository>
     </repositories>
     <dependencies>
         <!--Spigot API and NMS-->
@@ -77,6 +82,12 @@
             <scope>compile</scope>
         </dependency>
 
+        <dependency>
+            <groupId>de.themoep</groupId>
+            <artifactId>minedown</artifactId>
+            <version>1.7.1-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -25,11 +25,6 @@
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
-
-        <repository>
-            <id>minebench-repo</id>
-            <url>https://repo.minebench.de/</url>
-        </repository>
     </repositories>
     <dependencies>
         <!--Spigot API and NMS-->
@@ -79,13 +74,6 @@
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
             <version>3.0.0</version>
-            <scope>compile</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>de.themoep</groupId>
-            <artifactId>minedown</artifactId>
-            <version>1.7.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/nl/martenm/servertutorialplus/commands/sub/tutorials/InfoCommand.java
+++ b/src/main/java/nl/martenm/servertutorialplus/commands/sub/tutorials/InfoCommand.java
@@ -81,7 +81,7 @@ public class InfoCommand extends SimpleCommand {
             //Time
             sender.sendMessage("     " + ChatColor.GREEN + Lang.TIME + ": " + ChatColor.YELLOW + point.getTime() + " " + Lang.SECONDS);
             //Actionbar
-            if(point.getMessage_actionBar() != null && !point.getMessage_actionBar().equalsIgnoreCase("")) sender.sendMessage("     " + ChatColor.GREEN + "Actionbar: " + ChatColor.YELLOW + point.getMessage_actionBar());
+            if(point.getMessageActionbar() != null && !point.getMessageActionbar().equalsIgnoreCase("")) sender.sendMessage("     " + ChatColor.GREEN + "Actionbar: " + ChatColor.YELLOW + point.getMessageActionbar());
             //Title
             if(point.getTitleInfo() != null){
                 if(!point.getTitleInfo().title.equalsIgnoreCase("")) sender.sendMessage("     " + ChatColor.GREEN + "Title: " + ChatColor.YELLOW + ChatColor.translateAlternateColorCodes('&', point.getTitleInfo().title));

--- a/src/main/java/nl/martenm/servertutorialplus/points/ServerTutorialPoint.java
+++ b/src/main/java/nl/martenm/servertutorialplus/points/ServerTutorialPoint.java
@@ -37,13 +37,15 @@ public abstract class ServerTutorialPoint{
     protected ServerTutorialPlus plugin;
     protected PointType type;
 
+    protected BukkitTask actionbarRunnable = null;
+
     protected Location loc;
     protected List<String> message_chat;
     protected List<String> commands;
     protected List<FireWorkInfo> fireworks;
-    protected String message_actionBar;
-    protected double actionbar_show_after;
-    protected double actionbar_hide_after;
+    protected String messageActionbar;
+    protected double actionbarShowAfter;
+    protected double actionbarHideAfter;
     protected PlayerTitle titleInfo;
     protected PlayerSound soundInfo;
     protected List<PotionEffect> pointionEffects;
@@ -91,6 +93,7 @@ public abstract class ServerTutorialPoint{
             @Override
             public void stop() {
                 if(timerTask != null) timerTask.cancel();
+                if (actionbarRunnable != null) actionbarRunnable.cancel();
             }
         };
     }
@@ -153,16 +156,16 @@ public abstract class ServerTutorialPoint{
         //endregion
 
         //region actionbar
-        if (message_actionBar != null && actionbar_hide_after > actionbar_show_after) {
-            new BukkitRunnable() {
-                final double showAfterTicks = actionbar_show_after * 20;
-                final double hideAfterTicks = actionbar_hide_after * 20;
+        if (messageActionbar != null && actionbarHideAfter > actionbarShowAfter) {
+            actionbarRunnable = new BukkitRunnable() {
+                final double showAfterTicks = actionbarShowAfter * 20;
+                final double hideAfterTicks = actionbarHideAfter * 20;
                 int ticksPassed = 0;
                 @Override
                 public void run() {
                     if (ticksPassed >= showAfterTicks && ticksPassed < hideAfterTicks) {
                         player.spigot().sendMessage(ChatMessageType.ACTION_BAR,
-                                new TextComponent(PluginUtils.replaceVariables(plugin.placeholderAPI, player, message_actionBar)));
+                                new TextComponent(PluginUtils.replaceVariables(plugin.placeholderAPI, player, messageActionbar)));
                     } else if (ticksPassed > hideAfterTicks || ticksPassed > time * 20) {
                         player.spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(""));
                         this.cancel();
@@ -213,9 +216,9 @@ public abstract class ServerTutorialPoint{
         message_chat = tutorialSaves.getStringList("tutorials." + ID + ".points." + i + ".messages");
         commands = tutorialSaves.getStringList("tutorials." + ID + ".points." + i + ".commands");
 
-        message_actionBar = tutorialSaves.getString("tutorials." + ID + ".points." + i + ".actionbar.message");
-        actionbar_show_after = tutorialSaves.getDouble("tutorials." + ID + ".points." + i + ".actionbar.show-after", 0);
-        actionbar_hide_after = tutorialSaves.getDouble("tutorials." + ID + ".points." + i + ".actionbar.hide-after", time);
+        messageActionbar = tutorialSaves.getString("tutorials." + ID + ".points." + i + ".actionbar.message");
+        actionbarShowAfter = tutorialSaves.getDouble("tutorials." + ID + ".points." + i + ".actionbar.show-after", 0);
+        actionbarHideAfter = tutorialSaves.getDouble("tutorials." + ID + ".points." + i + ".actionbar.hide-after", time);
         lockPlayer = tutorialSaves.getBoolean("tutorials." + ID + ".points." + i + ".locplayer");
         lockView = tutorialSaves.getBoolean("tutorials." + ID + ".points." + i + ".locview");
         flying = tutorialSaves.getBoolean("tutorials." + ID + ".points." + i + ".setFly");
@@ -281,9 +284,9 @@ public abstract class ServerTutorialPoint{
         tutorialSaves.set("tutorials." + key + ".points." + i + ".locplayer", lockPlayer);
         tutorialSaves.set("tutorials." + key + ".points." + i + ".locview", lockView);
         tutorialSaves.set("tutorials." + key + ".points." + i + ".messages", message_chat);
-        tutorialSaves.set("tutorials." + key + ".points." + i + ".actionbar.message", message_actionBar);
-        tutorialSaves.set("tutorials." + key + ".points." + i + ".actionbar.show-after", actionbar_show_after);
-        tutorialSaves.set("tutorials." + key + ".points." + i + ".actionbar.hide-after", actionbar_hide_after);
+        tutorialSaves.set("tutorials." + key + ".points." + i + ".actionbar.message", messageActionbar);
+        tutorialSaves.set("tutorials." + key + ".points." + i + ".actionbar.show-after", actionbarShowAfter);
+        tutorialSaves.set("tutorials." + key + ".points." + i + ".actionbar.hide-after", actionbarHideAfter);
         tutorialSaves.set("tutorials." + key + ".points." + i + ".commands", commands);
         if(flying) tutorialSaves.set("tutorials." + key + ".points." + i + ".setFly", flying);
 
@@ -372,12 +375,20 @@ public abstract class ServerTutorialPoint{
         this.loc = loc;
     }
 
-    public String getMessage_actionBar() {
-        return message_actionBar;
+    public String getMessageActionbar() {
+        return messageActionbar;
     }
 
-    public void setMessage_actionBar(String message_actionBar) {
-        this.message_actionBar = message_actionBar;
+    public void setMessageActionbar(String message_actionBar) {
+        this.messageActionbar = message_actionBar;
+    }
+
+    public void setActionbarShowAfter(double actionbarShowAfter) {
+        this.actionbarShowAfter = actionbarShowAfter;
+    }
+
+    public void setActionbarHideAfter(double actionbarHideAfter) {
+        this.actionbarHideAfter = actionbarHideAfter;
     }
 
     public PlayerTitle getTitleInfo() {

--- a/src/main/java/nl/martenm/servertutorialplus/points/ServerTutorialPoint.java
+++ b/src/main/java/nl/martenm/servertutorialplus/points/ServerTutorialPoint.java
@@ -216,7 +216,7 @@ public abstract class ServerTutorialPoint{
 
         message_actionBar = tutorialSaves.getString("tutorials." + ID + ".points." + i + ".actionbar.message");
         actionbar_show_after = tutorialSaves.getDouble("tutorials." + ID + ".points." + i + ".actionbar.show-after", 0);
-        actionbar_hide_after = tutorialSaves.getDouble("tutorials." + ID + ".points." + i + ".actionbar.hide-after", -1);
+        actionbar_hide_after = tutorialSaves.getDouble("tutorials." + ID + ".points." + i + ".actionbar.hide-after", time);
         lockPlayer = tutorialSaves.getBoolean("tutorials." + ID + ".points." + i + ".locplayer");
         lockView = tutorialSaves.getBoolean("tutorials." + ID + ".points." + i + ".locview");
         flying = tutorialSaves.getBoolean("tutorials." + ID + ".points." + i + ".setFly");

--- a/src/main/java/nl/martenm/servertutorialplus/points/ServerTutorialPoint.java
+++ b/src/main/java/nl/martenm/servertutorialplus/points/ServerTutorialPoint.java
@@ -1,7 +1,6 @@
 package nl.martenm.servertutorialplus.points;
 
 import com.cryptomorin.xseries.messages.Titles;
-import de.themoep.minedown.MineDown;
 import nl.martenm.servertutorialplus.ServerTutorialPlus;
 import nl.martenm.servertutorialplus.helpers.Config;
 import nl.martenm.servertutorialplus.helpers.PluginUtils;
@@ -163,7 +162,7 @@ public abstract class ServerTutorialPoint{
                 public void run() {
                     if (ticksPassed >= showAfterTicks && ticksPassed < hideAfterTicks) {
                         player.spigot().sendMessage(ChatMessageType.ACTION_BAR,
-                                new MineDown(PluginUtils.replaceVariables(plugin.placeholderAPI, player, message_actionBar)).toComponent());
+                                new TextComponent(PluginUtils.replaceVariables(plugin.placeholderAPI, player, message_actionBar)));
                     } else if (ticksPassed > hideAfterTicks || ticksPassed > time * 20) {
                         player.spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(""));
                         this.cancel();

--- a/src/main/java/nl/martenm/servertutorialplus/points/custom/CheckPoint.java
+++ b/src/main/java/nl/martenm/servertutorialplus/points/custom/CheckPoint.java
@@ -138,9 +138,9 @@ public class CheckPoint extends ServerTutorialPoint {
                         }
 
                         if (repeatActionbar) {
-                            if (message_actionBar != null) {
+                            if (messageActionbar != null) {
                                 //NeedsReflection.sendActionBar(player, PluginUtils.replaceVariables(plugin.placeholderAPI, player, message_actionBar));
-                                player.spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(PluginUtils.replaceVariables(plugin.placeholderAPI, player, message_actionBar)));
+                                player.spigot().sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(PluginUtils.replaceVariables(plugin.placeholderAPI, player, messageActionbar)));
                             }
                         }
                     }

--- a/src/main/java/nl/martenm/servertutorialplus/points/editor/args/ActionbarArg.java
+++ b/src/main/java/nl/martenm/servertutorialplus/points/editor/args/ActionbarArg.java
@@ -20,26 +20,45 @@ public class ActionbarArg extends PointArg {
     @Override
     public boolean run(ServerTutorial serverTutorial, ServerTutorialPoint point, CommandSender sender, String[] args) {
         if(args.length < 1){
-            sender.sendMessage(Lang.WRONG_COMMAND_FORMAT + "/st editpoint <t> <p> actionbar <clear/set>");
+            sender.sendMessage(Lang.WRONG_COMMAND_FORMAT + "/st editpoint <t> <p> actionbar <clear/message/show-after/hide-after> <args>");
             return false;
         }
 
         switch (args[0]) {
             case "clear":
-                point.setMessage_actionBar(null);
+                point.setMessageActionbar(null);
                 break;
-            case "set":
+            case "message":
                 if (args.length < 2) {
                     sender.sendMessage(Lang.ERROR_ATLEAST_ONE_WORD.toString());
                     return false;
                 }
 
                 String message = StringUtils.join(args, ' ', 1, args.length);
-                point.setMessage_actionBar(message);
+                point.setMessageActionbar(message);
                 break;
-
+            case "show-after":
+                double showAfter;
+                try {
+                    showAfter = Double.parseDouble(args[1]);
+                } catch (NumberFormatException e) {
+                    sender.sendMessage(Lang.ERROR_INVALID_NUMBNER.toString());
+                    return false;
+                }
+                point.setActionbarShowAfter(showAfter);
+                break;
+            case "hide-after":
+                double hideAfter;
+                try {
+                    hideAfter = Double.parseDouble(args[1]);
+                } catch (NumberFormatException e) {
+                    sender.sendMessage(Lang.ERROR_INVALID_NUMBNER.toString());
+                    return false;
+                }
+                point.setActionbarHideAfter(hideAfter);
+                break;
             default:
-                sender.sendMessage(Lang.WRONG_COMMAND_FORMAT + "/st editpoint <t> <p> actionbar <clear/set>");
+                sender.sendMessage(Lang.WRONG_COMMAND_FORMAT + "/st editpoint <t> <p> actionbar <clear/set/show-after/hide-after>");
                 return false;
         }
         return true;


### PR DESCRIPTION
Hi, this PR adds a `hide-after` and `show-after` option to the actionbar. The runnable controlling when to show and hide the actionbar automatically cancels when the point has finished or the hide-after has been reached, so it will not lead to any overload on the server.

### Example:
Configuration:
````yaml
actionbar:
  message: '&4Text'
  show-after: 2.5
  hide-after: 3.5
````

https://github.com/MartenM/ServerTutorialPlus/assets/131914029/7c9395b2-bdcb-4bb9-9a18-598499db0307




- by default, the text will stay on screen until the point has finished
- to hide the text when needed, an empty actionbar message will be sent
- `show-after` and `hide-after` should both be specified in seconds