### PR TITLE
Added bossbar feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,10 +26,6 @@
             <url>https://jitpack.io</url>
         </repository>
 
-        <repository>
-            <id>minebench-repo</id>
-            <url>https://repo.minebench.de/</url>
-        </repository>
     </repositories>
     <dependencies>
         <!--Spigot API and NMS-->
@@ -79,13 +75,6 @@
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
             <version>3.0.0</version>
-            <scope>compile</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>de.themoep</groupId>
-            <artifactId>minedown</artifactId>
-            <version>1.7.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,11 @@
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
+
+        <repository>
+            <id>minebench-repo</id>
+            <url>https://repo.minebench.de/</url>
+        </repository>
     </repositories>
     <dependencies>
         <!--Spigot API and NMS-->
@@ -74,6 +79,13 @@
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
             <version>3.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>de.themoep</groupId>
+            <artifactId>minedown</artifactId>
+            <version>1.7.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
 

--- a/src/main/java/nl/martenm/servertutorialplus/objects/TutorialController.java
+++ b/src/main/java/nl/martenm/servertutorialplus/objects/TutorialController.java
@@ -9,6 +9,8 @@ import nl.martenm.servertutorialplus.helpers.PluginUtils;
 import nl.martenm.servertutorialplus.helpers.dataholders.OldValuesPlayer;
 import nl.martenm.servertutorialplus.points.IPlayPoint;
 import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.boss.BossBar;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -104,6 +106,11 @@ public class TutorialController {
                 player.setGameMode(oldValuesPlayer.getGamemode());
                 if (originalLocation) {
                     player.teleport(oldValuesPlayer.getLoc());
+                }
+
+                BossBar bossBar = Bukkit.getBossBar(new NamespacedKey(plugin, "bossbar"));
+                if (bossBar != null) {
+                    bossBar.removeAll();
                 }
             // });
         }

--- a/src/main/java/nl/martenm/servertutorialplus/points/ServerTutorialPoint.java
+++ b/src/main/java/nl/martenm/servertutorialplus/points/ServerTutorialPoint.java
@@ -12,9 +12,10 @@ import net.md_5.bungee.api.ChatMessageType;
 import net.md_5.bungee.api.chat.TextComponent;
 import nl.martenm.servertutorialplus.points.editor.PointArg;
 import nl.martenm.servertutorialplus.points.editor.args.*;
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.Sound;
+import org.bukkit.*;
+import org.bukkit.boss.BarColor;
+import org.bukkit.boss.BarStyle;
+import org.bukkit.boss.BossBar;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Firework;
 import org.bukkit.entity.Player;
@@ -42,6 +43,12 @@ public abstract class ServerTutorialPoint{
     protected List<String> commands;
     protected List<FireWorkInfo> fireworks;
     protected String message_actionBar;
+    protected String bossBarTitle;
+    protected double bossBarProgress;
+    protected BarColor bossBarColor;
+    protected BarStyle bossBarStyle;
+    protected double bossBarShowAfter;
+    protected double bossBarHideAfter;
     protected PlayerTitle titleInfo;
     protected PlayerSound soundInfo;
     protected List<PotionEffect> pointionEffects;
@@ -157,6 +164,42 @@ public abstract class ServerTutorialPoint{
         }
         //endregion
 
+        if (bossBarTitle != null && bossBarHideAfter > bossBarShowAfter) {
+
+            BossBar oldBar = Bukkit.getBossBar(new NamespacedKey(plugin, "bossbar"));
+            if (oldBar != null) {
+                oldBar.removeAll();
+            }
+
+            new BukkitRunnable() {
+                final BossBar bossBar = Bukkit.getServer().createBossBar(new NamespacedKey(plugin, "bossbar"), bossBarTitle,
+                        bossBarColor, bossBarStyle);
+                final int showAfterTicks = (int) (bossBarShowAfter * 20);
+                final int hideAfterTicks = (int) (bossBarHideAfter * 20);
+                int ticksPassed = 0;
+                {
+                    if (bossBarProgress > 1.0) {
+                        bossBarProgress = 1.0;
+                    }
+                    if (bossBarProgress < 0.0) {
+                        bossBarProgress = 0.0;
+                    }
+                    bossBar.setProgress(bossBarProgress);
+                }
+                @Override
+                public void run() {
+                    if (ticksPassed >= showAfterTicks && !bossBar.getPlayers().contains(player)) {
+                        bossBar.addPlayer(player);
+                    }
+                    if (ticksPassed >= hideAfterTicks || ticksPassed > time * 20) {
+                        bossBar.removePlayer(player);
+                        this.cancel();
+                    }
+                    ticksPassed += 2;
+                }
+            }.runTaskTimer(plugin, 0, 2);
+        }
+
         //region commands
         for (String command : commands) {
             Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), PluginUtils.replaceVariables(plugin.placeholderAPI, player, command));
@@ -198,9 +241,28 @@ public abstract class ServerTutorialPoint{
         commands = tutorialSaves.getStringList("tutorials." + ID + ".points." + i + ".commands");
 
         message_actionBar = tutorialSaves.getString("tutorials." + ID + ".points." + i + ".actionbar");
+        bossBarTitle = tutorialSaves.getString("tutorials." + ID + ".points." + i + ".bossbar.title");
+        bossBarProgress = tutorialSaves.getDouble("tutorials." + ID + ".points." + i + ".bossbar.progress", 1.0);
+        bossBarShowAfter = tutorialSaves.getDouble("tutorials." + ID + ".points." + i + ".bossbar.show-after", 0.0);
+        bossBarHideAfter = tutorialSaves.getDouble("tutorials." + ID + ".points." + i + ".bossbar.hide-after", time);
         lockPlayer = tutorialSaves.getBoolean("tutorials." + ID + ".points." + i + ".locplayer");
         lockView = tutorialSaves.getBoolean("tutorials." + ID + ".points." + i + ".locview");
         flying = tutorialSaves.getBoolean("tutorials." + ID + ".points." + i + ".setFly");
+
+        try {
+            String bossBarStyleString = tutorialSaves.getString("tutorials." + ID + ".points." + i + ".bossbar.style", "SOLID");
+            bossBarStyle = BarStyle.valueOf(bossBarStyleString.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            bossBarStyle = BarStyle.SOLID;
+        }
+
+        try {
+            String bossBarColorString = tutorialSaves.getString("tutorials." + ID + ".points." + i + ".bossbar.color", "WHITE");
+            bossBarColor = BarColor.valueOf(bossBarColorString.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            bossBarColor = BarColor.WHITE;
+        }
+
         /*
            Fire work meta!
         */
@@ -266,6 +328,15 @@ public abstract class ServerTutorialPoint{
         tutorialSaves.set("tutorials." + key + ".points." + i + ".actionbar", message_actionBar);
         tutorialSaves.set("tutorials." + key + ".points." + i + ".commands", commands);
         if(flying) tutorialSaves.set("tutorials." + key + ".points." + i + ".setFly", flying);
+
+        if (bossBarTitle != null) {
+            tutorialSaves.set("tutorials." + key + ".points." + i + ".bossbar.title", bossBarTitle);
+            tutorialSaves.set("tutorials." + key + ".points." + i + ".bossbar.color", bossBarColor.name());
+            tutorialSaves.set("tutorials." + key + ".points." + i + ".bossbar.style", bossBarStyle.name());
+            tutorialSaves.set("tutorials." + key + ".points." + i + ".bossbar.progress", bossBarProgress);
+            tutorialSaves.set("tutorials." + key + ".points." + i + ".bossbar.show-after", bossBarShowAfter);
+            tutorialSaves.set("tutorials." + key + ".points." + i + ".bossbar.hide-after", bossBarHideAfter);
+        }
 
         if(titleInfo != null){
             tutorialSaves.set("tutorials." + key + ".points." + i + ".title.title", titleInfo.title);

--- a/src/main/java/nl/martenm/servertutorialplus/points/ServerTutorialPoint.java
+++ b/src/main/java/nl/martenm/servertutorialplus/points/ServerTutorialPoint.java
@@ -388,6 +388,7 @@ public abstract class ServerTutorialPoint{
         args.add(new MessagesArg());
         args.add(new CommandsArg());
         args.add(new ActionbarArg());
+        args.add(new BossBarArg());
         args.add(new FireworkArg());
         args.add(new PotionEffectArg());
         args.add(new SoundArg());
@@ -509,5 +510,29 @@ public abstract class ServerTutorialPoint{
 
     public void setFlying(boolean setFlying) {
         this.flying = setFlying;
+    }
+
+    public void setBossBarTitle(String bossBarTitle) {
+        this.bossBarTitle = bossBarTitle;
+    }
+
+    public void setBossBarProgress(double bossBarProgress) {
+        this.bossBarProgress = bossBarProgress;
+    }
+
+    public void setBossBarColor(BarColor bossBarColor) {
+        this.bossBarColor = bossBarColor;
+    }
+
+    public void setBossBarStyle(BarStyle bossBarStyle) {
+        this.bossBarStyle = bossBarStyle;
+    }
+
+    public void setBossBarShowAfter(double bossBarShowAfter) {
+        this.bossBarShowAfter = bossBarShowAfter;
+    }
+
+    public void setBossBarHideAfter(double bossBarHideAfter) {
+        this.bossBarHideAfter = bossBarHideAfter;
     }
 }

--- a/src/main/java/nl/martenm/servertutorialplus/points/ServerTutorialPoint.java
+++ b/src/main/java/nl/martenm/servertutorialplus/points/ServerTutorialPoint.java
@@ -38,6 +38,8 @@ public abstract class ServerTutorialPoint{
     protected ServerTutorialPlus plugin;
     protected PointType type;
 
+    protected BukkitTask bossbarRunnable = null;
+
     protected Location loc;
     protected List<String> message_chat;
     protected List<String> commands;
@@ -96,6 +98,7 @@ public abstract class ServerTutorialPoint{
             @Override
             public void stop() {
                 if(timerTask != null) timerTask.cancel();
+                if (bossbarRunnable != null) bossbarRunnable.cancel();
             }
         };
     }
@@ -171,7 +174,7 @@ public abstract class ServerTutorialPoint{
                 oldBar.removeAll();
             }
 
-            new BukkitRunnable() {
+            bossbarRunnable = new BukkitRunnable() {
                 final BossBar bossBar = Bukkit.getServer().createBossBar(new NamespacedKey(plugin, "bossbar"),
                         ChatColor.translateAlternateColorCodes('&', bossBarTitle), bossBarColor, bossBarStyle);
                 final int showAfterTicks = (int) (bossBarShowAfter * 20);

--- a/src/main/java/nl/martenm/servertutorialplus/points/ServerTutorialPoint.java
+++ b/src/main/java/nl/martenm/servertutorialplus/points/ServerTutorialPoint.java
@@ -172,8 +172,8 @@ public abstract class ServerTutorialPoint{
             }
 
             new BukkitRunnable() {
-                final BossBar bossBar = Bukkit.getServer().createBossBar(new NamespacedKey(plugin, "bossbar"), bossBarTitle,
-                        bossBarColor, bossBarStyle);
+                final BossBar bossBar = Bukkit.getServer().createBossBar(new NamespacedKey(plugin, "bossbar"),
+                        ChatColor.translateAlternateColorCodes('&', bossBarTitle), bossBarColor, bossBarStyle);
                 final int showAfterTicks = (int) (bossBarShowAfter * 20);
                 final int hideAfterTicks = (int) (bossBarHideAfter * 20);
                 int ticksPassed = 0;

--- a/src/main/java/nl/martenm/servertutorialplus/points/editor/args/BossBarArg.java
+++ b/src/main/java/nl/martenm/servertutorialplus/points/editor/args/BossBarArg.java
@@ -1,0 +1,95 @@
+package nl.martenm.servertutorialplus.points.editor.args;
+
+import nl.martenm.servertutorialplus.language.Lang;
+import nl.martenm.servertutorialplus.objects.ServerTutorial;
+import nl.martenm.servertutorialplus.points.ServerTutorialPoint;
+import nl.martenm.servertutorialplus.points.editor.PointArg;
+import org.apache.commons.lang3.StringUtils;
+import org.bukkit.boss.BarColor;
+import org.bukkit.boss.BarStyle;
+import org.bukkit.command.CommandSender;
+
+public class BossBarArg extends PointArg {
+
+    public BossBarArg() {
+        super("bossbar");
+    }
+
+    @Override
+    public boolean run(ServerTutorial serverTutorial, ServerTutorialPoint point, CommandSender sender, String[] args) {
+        if(args.length < 1){
+            sender.sendMessage(Lang.WRONG_COMMAND_FORMAT + "/st editpoint <t> <p> bossbar <title/progress/color/style/show-after/hide-after> <args>");
+            return false;
+        }
+
+        if (args.length < 2) {
+            sender.sendMessage(Lang.ERROR_ATLEAST_ONE_WORD.toString());
+            return false;
+        }
+
+        switch (args[0]) {
+            case "title":
+                String title = StringUtils.join(args, ' ', 1, args.length);
+                point.setBossBarTitle(title);
+                break;
+            case "progress":
+                double progress;
+                try {
+                    progress = Double.parseDouble(args[1]);
+                    if (progress > 1.0 || progress < 0.0) {
+                        sender.sendMessage(Lang.ERROR_INVALID_NUMBNER + "/st editpoint <t> <p> bossbar progress <progress 0.0-1.0>");
+                        return false;
+                    }
+                } catch (NumberFormatException e) {
+                    sender.sendMessage(Lang.ERROR_INVALID_NUMBNER + "/st editpoint <t> <p> bossbar progress <progress 0.0 - 1.0>");
+                    return false;
+                }
+                point.setBossBarProgress(progress);
+                break;
+            case "color":
+                BarColor color;
+                try {
+                    color = BarColor.valueOf(args[1]);
+                } catch (IllegalArgumentException e) {
+                    sender.sendMessage(Lang.INVALID_ARGS + "/st editpoint <t> <p> bossbar color <BarColor>");
+                    return false;
+                }
+                point.setBossBarColor(color);
+                break;
+            case "style":
+                BarStyle style;
+                try {
+                    style = BarStyle.valueOf(args[1]);
+                } catch (IllegalArgumentException e) {
+                    sender.sendMessage(Lang.INVALID_ARGS + "/st editpoint <t> <p> bossbar style <BarStyle>");
+                    return false;
+                }
+                point.setBossBarStyle(style);
+                break;
+            case "show-after":
+                double showAfter;
+                try {
+                    showAfter = Double.parseDouble(args[1]);
+                } catch (NumberFormatException e) {
+                    sender.sendMessage(Lang.ERROR_INVALID_NUMBNER + "/st editpoint <t> <p> bossbar show-after <show-after seconds>");
+                    return false;
+                }
+                point.setBossBarShowAfter(showAfter);
+                break;
+            case "hide-after":
+                double hideAfter;
+                try {
+                    hideAfter = Double.parseDouble(args[1]);
+                } catch (NumberFormatException e) {
+                    sender.sendMessage(Lang.ERROR_INVALID_NUMBNER + "/st editpoint <t> <p> bossbar hide-after <hide-after seconds>");
+                    return false;
+                }
+                point.setBossBarHideAfter(hideAfter);
+                break;
+            default:
+                sender.sendMessage(Lang.WRONG_COMMAND_FORMAT + "/st editpoint <t> <p> bossbar <title/progress/color/style/show-after/hide-after> <args>");
+                return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/nl/martenm/servertutorialplus/points/editor/args/BossBarArg.java
+++ b/src/main/java/nl/martenm/servertutorialplus/points/editor/args/BossBarArg.java
@@ -37,11 +37,11 @@ public class BossBarArg extends PointArg {
                 try {
                     progress = Double.parseDouble(args[1]);
                     if (progress > 1.0 || progress < 0.0) {
-                        sender.sendMessage(Lang.ERROR_INVALID_NUMBNER + "/st editpoint <t> <p> bossbar progress <progress 0.0-1.0>");
+                        sender.sendMessage(Lang.ERROR_INVALID_NUMBNER.toString());
                         return false;
                     }
                 } catch (NumberFormatException e) {
-                    sender.sendMessage(Lang.ERROR_INVALID_NUMBNER + "/st editpoint <t> <p> bossbar progress <progress 0.0 - 1.0>");
+                    sender.sendMessage(Lang.ERROR_INVALID_NUMBNER.toString());
                     return false;
                 }
                 point.setBossBarProgress(progress);
@@ -51,7 +51,7 @@ public class BossBarArg extends PointArg {
                 try {
                     color = BarColor.valueOf(args[1]);
                 } catch (IllegalArgumentException e) {
-                    sender.sendMessage(Lang.INVALID_ARGS + "/st editpoint <t> <p> bossbar color <BarColor>");
+                    sender.sendMessage(Lang.INVALID_ARGS.toString());
                     return false;
                 }
                 point.setBossBarColor(color);
@@ -61,7 +61,7 @@ public class BossBarArg extends PointArg {
                 try {
                     style = BarStyle.valueOf(args[1]);
                 } catch (IllegalArgumentException e) {
-                    sender.sendMessage(Lang.INVALID_ARGS + "/st editpoint <t> <p> bossbar style <BarStyle>");
+                    sender.sendMessage(Lang.INVALID_ARGS.toString());
                     return false;
                 }
                 point.setBossBarStyle(style);
@@ -71,7 +71,7 @@ public class BossBarArg extends PointArg {
                 try {
                     showAfter = Double.parseDouble(args[1]);
                 } catch (NumberFormatException e) {
-                    sender.sendMessage(Lang.ERROR_INVALID_NUMBNER + "/st editpoint <t> <p> bossbar show-after <show-after seconds>");
+                    sender.sendMessage(Lang.ERROR_INVALID_NUMBNER.toString());
                     return false;
                 }
                 point.setBossBarShowAfter(showAfter);
@@ -81,7 +81,7 @@ public class BossBarArg extends PointArg {
                 try {
                     hideAfter = Double.parseDouble(args[1]);
                 } catch (NumberFormatException e) {
-                    sender.sendMessage(Lang.ERROR_INVALID_NUMBNER + "/st editpoint <t> <p> bossbar hide-after <hide-after seconds>");
+                    sender.sendMessage(Lang.ERROR_INVALID_NUMBNER.toString());
                     return false;
                 }
                 point.setBossBarHideAfter(hideAfter);


### PR DESCRIPTION
Hello, this PR adds a bossbar option.

## Options
the bossbar feature supports the following options:
| Setting    | What it does                                                                                                    |
|------------|-----------------------------------------------------------------------------------------------------------------|
| title      | message shown on the bossbar (supports '&' color codes)                                                                                   |
| progress   | the progress of the bossbar (between 0.0 and 1.0)                                                                                    |
| color      | color of the bossbar ([supported colors](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/boss/BarColor.html)) |
| style      | style of the bossbar ([supported styles](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/boss/BarStyle.html)) |
| show-after | time until the bossbar should be shown (in seconds)                                                                    |
| hide-after | time until the bossbar should be hidden (in seconds)                                                            |

The runnable controlling when to hide and show the bossbar will also automatically cancel itself when either the point has finished or `hide-after` has been reached to save resources.

### Default values
title: empty, bossbar will not be shown
progress: 1.0
color: WHITE
style: SOLID
show-after: 0.0
hide-after: duration of the point

## Example
````yaml
bossbar:
  title: '&4Text'
  color: BLUE
  style: SEGMENTED_12
  progress: 0.6
  show-after: 2.5
  hide-after: 3.5
````

https://github.com/MartenM/ServerTutorialPlus/assets/131914029/684f9ff2-624c-414f-866c-f96a9102eb4d

